### PR TITLE
added DigiDates.de API to apivault entries

### DIFF
--- a/backend/data/entries.json
+++ b/backend/data/entries.json
@@ -1,5 +1,5 @@
 {
-   "count": 1425,
+   "count": 1426,
    "entries": [
       {
          "API": "AdoptAPet",
@@ -2007,6 +2007,15 @@
          "Cors": "unknown",
          "Link": "https://www.cryptonator.com/api/",
          "Category": "Cryptocurrency"
+      },
+      {
+         "API": "DigiDates.de",
+         "Description": "Open Rest API for various date and time calculations",
+         "Auth": "",
+         "HTTPS": true,
+         "Cors": "yes",
+         "Link": "https://digidates.de/en/",
+         "Category": "Calendar"
       },
       {
          "API": "dYdX",


### PR DESCRIPTION
# API Added
Issue referred -> #47 

## Info
API Name: DigiDates.de
Description: Open Rest API for various date and time calculations
Category: Calendar
What Auth is used (ex: Api Key): none
HTTPS: true
CORS: true
Api Link: https://digidates.de/en/
