### PR TITLE
[issue #67] make changes to theme to allow it to persist in browser storage referencing 

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,8 +1,10 @@
 <script setup>
-import { onMounted } from "vue";
+import { onMounted, inject } from "vue";
+
+const theme = inject("theme");
 
 onMounted(() => {
-  document.body.setAttribute("data-theme", "dark");
+  document.body.setAttribute("data-theme", theme.value);
 });
 </script>
 

--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -61,15 +61,12 @@
 
 <script setup>
 import packageJson from '../../package.json';
-import { computed } from "vue";
-const props = defineProps({
-  scheme: {
-    type: String,
-    required: false,
-  },
-});
+import { computed, inject } from "vue";
+
+const theme = inject("theme");
+
 const logoMode = computed(() => {
-  if (props.scheme === "dark") {
+  if (theme.value === "dark") {
     return "/img/apivault-dark-nobg.png";
   }
   return "/img/apivault-light-nobg.png";

--- a/frontend/src/components/Hero.vue
+++ b/frontend/src/components/Hero.vue
@@ -14,42 +14,18 @@
 
 <script setup>
 import Logo from "./Logo.vue";
-import { reactive, computed } from "vue";
+import { reactive, computed, inject } from "vue";
 
-const emit = defineEmits(["update:colorScheme"]);
-const state = reactive({
-  theme: "dark",
-});
+const theme = inject("theme");
 
 // Compute the image source based on the current theme
 const imageSource = computed(() => {
-  if (state.theme === "dark") {
+  if (theme.value === "dark") {
     return "/img/apivault-dark-nobg.png";
   } else {
     return "/img/apivault-light-nobg.png";
   }
 });
-
-/**
-
-Creates a new MutationObserver that listens for mutations in the 
-mutationsList passed to the function. When a mutation of type "attributes" 
-occurs and the data-theme attribute has changed, sets the value of state.theme 
-to the new data-theme attribute and emits an "update:colorScheme" 
-event with the new state.theme value.
-*/
-const observer = new MutationObserver((mutationsList) => {
-  mutationsList.forEach((mutation) => {
-    if (
-      mutation.type === "attributes" &&
-      mutation.attributeName === "data-theme"
-    ) {
-      state.theme = mutation.target.getAttribute("data-theme");
-      emit("update:colorScheme", state.theme);
-    }
-  });
-});
-observer.observe(document.body, { attributes: true });
 </script>
 
 <style scoped>

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -139,36 +139,37 @@ const number = ref(0);
 const github = reactive({
   number: 0,
 });
-const colorScheme = inject("colorScheme");
+const theme = inject("theme");
 const categoriesAttributes = inject("categoryMapping");
-
-var iconTheme = ref("fa-solid fa-sun");
-var iconThemeText = ref("Dark Mode");
-var logoPath = ref("/img/apivault-dark-nobg.png");
+const themeIcons = {
+  light: "fa-solid fa-sun",
+  dark: "fa-solid fa-moon"
+}
+const iconTheme = ref(themeIcons[theme.value]);
+const iconThemeText = ref(theme.value[0].toUpperCase() + theme.value.slice(1, theme.value.length) + " Mode");
+const logoPath = ref(`/img/apivault-${theme.value}-nobg.png`);
 
 /**
 
 Toggles the color scheme of the document body between light and dark mode. 
-Updates the values of iconThemeText, colorScheme, logoPath, and iconTheme 
+Updates the values of iconThemeText, theme, logoPath, and iconTheme 
 based on the new color scheme. Returns the new value of iconTheme to display.
 @returns {String} - The new value of iconTheme to display
 */
 const setMode = () => {
-  const theme = document.body.getAttribute("data-theme");
-
-  if (theme === "dark" || theme === null) {
-    document.querySelector("body")?.setAttribute("data-theme", "light");
-    iconThemeText.value = "Light Mode";
-    colorScheme.value = "dark";
-    logoPath.value = "/img/apivault-light-nobg.png";
-    return (iconTheme.value = "fa-solid fa-moon");
+  if (theme.value === "dark" || theme.value === undefined) {
+    theme.value = "light";
+    localStorage.setItem("APIVaultTheme", "light");
   } else {
-    document.querySelector("body")?.setAttribute("data-theme", "dark");
-    iconThemeText.value = "Dark Mode";
-    colorScheme.value = "light";
-    logoPath.value = "/img/apivault-dark-nobg.png";
-    return (iconTheme.value = "fa-solid fa-sun");
+    theme.value = "dark";
+    localStorage.setItem("APIVaultTheme", "dark");
   }
+  const themeText = theme.value[0].toUpperCase() + theme.value.slice(1, theme.value.length) + " Mode";
+
+  document.querySelector("body")?.setAttribute("data-theme", theme.value);
+  iconThemeText.value = themeText;
+  iconTheme.value = themeIcons[theme.value];
+  logoPath.value = `/img/apivault-${theme.value}-nobg.png`;
 };
 
 /**

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,4 @@
-import { createApp, ref } from "vue";
+import { createApp, ref, reactive } from "vue";
 import App from "./App.vue";
 import "./normalize.css";
 import "./style.css";
@@ -92,6 +92,7 @@ import {
 
 import router from "./router/router";
 import { categoriesProperties } from "@/utilities/categoryMapping.js";
+import { getTheme } from "./utilities/themeHandler";
 
 library.add(
   fas,
@@ -166,7 +167,9 @@ library.add(
 );
 
 // global variables
-const colorScheme = ref("dark");
+const scheme = ref(getTheme());
+const theme = reactive(scheme);
+
 if (import.meta.env.VITE_APP_MODE === "prod") {
   // firebase config
   const firebaseConfig = {
@@ -185,6 +188,6 @@ createApp(App)
   .use(router)
   .use(bootstrap)
   .provide("categoryMapping", categoriesProperties)
-  .provide("colorScheme", colorScheme)
+  .provide("theme", theme)
   .component("font-awesome-icon", FontAwesomeIcon)
   .mount("#app");

--- a/frontend/src/pages/ContributorsView.vue
+++ b/frontend/src/pages/ContributorsView.vue
@@ -6,7 +6,7 @@
     <Sidebar />
     <ContentBody title="WONDERFUL PEOPLE ❤️">
       <template #heroAreaContent>
-        <Hero @update:colorScheme="handleChangeScheme" />
+        <Hero />
       </template>
       <template #cardAreaContent>
         <div class="row">
@@ -24,7 +24,7 @@
         </div>
       </template>
       <template #footerArea>
-        <Footer :scheme="scheme.color" />
+        <Footer />
       </template>
     </ContentBody>
   </BodyFlex>
@@ -48,12 +48,4 @@ onMounted(async () => {
   contributors.value = await getContributors();
   isLoading.value = false;
 });
-
-const scheme = reactive({
-  color: "dark",
-});
-
-const handleChangeScheme = (val) => {
-  scheme.color = val;
-};
 </script>

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -6,7 +6,7 @@
     <Sidebar />
     <ContentBody :title="categorySearched.category">
       <template #heroAreaContent>
-        <Hero @update:colorScheme="handleChangeScheme" />
+        <Hero />
       </template>
       <template #topAreaContent>
         <SearchBar @search:apiSearch="handleSearch" />
@@ -35,7 +35,7 @@
         </div>
       </template>
       <template #footerArea>
-        <Footer :scheme="scheme.color" />
+        <Footer />
       </template>
     </ContentBody>
   </BodyFlex>
@@ -53,14 +53,6 @@ import Card from "@/components/Card.vue";
 import Hero from "@/components/Hero.vue";
 import getApiData from "@/components/api/randomApis.js";
 import LoadingEffect from "@/components/LoadingEffect.vue";
-
-const scheme = reactive({
-  color: "dark",
-});
-
-const handleChangeScheme = (val) => {
-  scheme.color = val;
-};
 
 let apiData = ref(null);
 let apiSearched = ref(null);

--- a/frontend/src/pages/categories/[category].vue
+++ b/frontend/src/pages/categories/[category].vue
@@ -12,7 +12,7 @@
         <SearchBar @search:apiSearch="handleSearch" />
       </template>
       <template #heroAreaContent>
-        <Hero @update:colorScheme="handleChangeScheme" />
+        <Hero />
       </template>
       <template #cardAreaContent>
         <div class="row">
@@ -37,7 +37,7 @@
         </div>
       </template>
       <template #footerArea>
-        <Footer :scheme="scheme.color" />
+        <Footer />
       </template>
     </ContentBody>
   </BodyFlex>
@@ -74,14 +74,6 @@ onBeforeUpdate(async () => {
   isNullCategory.value ? apiData.value.length === 0 : false;
   isLoading.value = false;
 });
-
-const scheme = reactive({
-  color: "dark",
-});
-
-const handleChangeScheme = (val) => {
-  scheme.color = val;
-};
 
 const categoryExist = categoriesAttributes.some(
   (category) => category.name === route.params.category

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -53,7 +53,6 @@ body {
 
 
 * {
-  transition: all 0.1s ease-in;
   font-family: 'Titillium Web', sans-serif;
 }
 

--- a/frontend/src/utilities/themeHandler.js
+++ b/frontend/src/utilities/themeHandler.js
@@ -1,0 +1,14 @@
+export function getTheme() {
+    const theme = localStorage.getItem("APIVaultTheme");
+    const prefersLight = window.matchMedia("(prefers-color-scheme: light)");
+
+    if (theme !== "dark" && theme !== "light") {
+        if (prefersLight) {
+            localStorage.setItem("APIVaultTheme", "light");
+        } else {
+            localStorage.setItem("APIVaultTheme", "dark");
+        }
+    }
+
+    return localStorage.getItem('APIVaultTheme');
+}


### PR DESCRIPTION
This PR is refencing issue #67. 

Before, the theme did not persist and it was not as easy to follow in the code. Now, using a provider and injecting the theme, it is much easier to follow and debug.

**Screenshots**
Previously, theme would not persist and would flash when loading due to the transition being applied from CSS.

![2023-05-02 17-40-03](https://user-images.githubusercontent.com/44178907/235792185-3389df6e-81d3-4743-a95f-7bdb2a643ebc.gif)
