### PR TITLE
Fix tag color and dark theme default

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -19,7 +19,7 @@
   --text-color: #c0c0c0;
   --text-color-hover: #f2f2f2;
   --hr-color: #919191;
-  --card-attribute-color: rgb(202, 202, 202);
+  --card-attribute-color: rgb(245, 245, 245);
   --bg-card-attribute: rgb(77 77 77 / 20%);
   --nav-item-hover:#f0f0f0;
 }

--- a/frontend/src/utilities/themeHandler.js
+++ b/frontend/src/utilities/themeHandler.js
@@ -1,14 +1,14 @@
 export function getTheme() {
-    const theme = localStorage.getItem("APIVaultTheme");
-    const prefersLight = window.matchMedia("(prefers-color-scheme: light)");
+  const theme = localStorage.getItem("APIVaultTheme");
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
 
-    if (theme !== "dark" && theme !== "light") {
-        if (prefersLight) {
-            localStorage.setItem("APIVaultTheme", "light");
-        } else {
-            localStorage.setItem("APIVaultTheme", "dark");
-        }
+  if (theme !== "dark" && theme !== "light") {
+    if (prefersDark) {
+      localStorage.setItem("APIVaultTheme", "dark");
+    } else {
+      localStorage.setItem("APIVaultTheme", "light");
     }
+  }
 
-    return localStorage.getItem('APIVaultTheme');
+  return localStorage.getItem("APIVaultTheme");
 }


### PR DESCRIPTION
## Description
As title said, this PR provides:
- New color for border and text of card tags
- Default theme set to Dark

## Screenshot
<img width="1480" alt="image" src="https://user-images.githubusercontent.com/19678157/235904982-5273e926-a8e3-4386-8e79-92152eaadad2.png">
