### PR TITLE
Contributors link added to Footer

### DIFF
--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -6,13 +6,13 @@
       &copy; 2023 Exifly
       <br />
       Coded by those 
-      <a
-        href="https://apivault.dev/contributors"
+      <router-link 
         class="text-wrapper-authors"
         style="text-decoration: none; font-weight: 600"
+        to="/contributors"
       >
       wonderful people
-      </a>
+    </router-link>
     </p>
 
     <router-link


### PR DESCRIPTION
Fixed #94

Changes-

- Removed "Coded by gdjohn4s & flavioad " In the footer.

- The new text will be "Coded by those wonderful people 

screenshot-

![contributors-footer png ](https://user-images.githubusercontent.com/94035734/236238694-f4ed237d-3b9e-4df3-a178-154b79d85434.png)