### PR TITLE
Changed a link on the footer for software version string (Issue #131)

### DIFF
--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -24,7 +24,7 @@
 
     <ul class="nav col-md-4 justify-content-end">
       <li class="nav-item">
-        <a href="mailto:info@exifly.it" class="nav-link px-2 text-wrapper"
+        <a href="https://github.com/Exifly/ApiVault/releases/" class="nav-link px-2 text-wrapper"
           >{{packageJson.version}}</a
         >
       </li>


### PR DESCRIPTION
With regards to Issue #131 , I have made the changes to the footer where the version release when clicked directs the release log. 
 
![APIVault _ Your free API Database list](https://user-images.githubusercontent.com/110970889/236898963-a19c9cdb-ac92-45e5-b663-c5fc911c7b27.png)

### Pull Request Checklist
- [x] Code follows the established [CODE_OF_CONDUCT](https://github.com/Exifly/ApiVault/blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Code has been tested thoroughly and passes all tests.
- [x] All commit messages are descriptive and follow the established commit message format.
- [x] Pull request title follows the established pull request title format.
- [x] Pull request description clearly describes the changes included in the pull request.