### PR TITLE
(enhancement)  alignment of Trending category section and APIs sectio…

### DIFF
--- a/frontend/src/layouts/ContentBody.vue
+++ b/frontend/src/layouts/ContentBody.vue
@@ -89,6 +89,12 @@ onMounted(async () => {
   flex-direction: column;
   justify-content: center;
 }
+.container {
+  padding-right: 15px;
+  padding-left: 2px;
+  margin-right: auto;
+  margin-left: auto;
+}
 
 .flex-child {
   flex-direction: column;


### PR DESCRIPTION
#116 

Describe the bug
The "Trending" category section is not aligned with the APIs section, causing a misalignment issue.

To Reproduce
Open the website on any device.
Navigate to the homepage.
Observe the "Trending" category section and the APIs section.
Expected behavior
The "Trending" category section should be aligned with the API card section.

@tarunsamanta2k20 
![image](https://github.com/Exifly/ApiVault/assets/55488549/b931cd1e-6b2a-4ced-a991-1d59dab71c96)
