### PR TITLE
Changed description font size in API card to 15px #152

### DIFF
--- a/frontend/src/components/Card.vue
+++ b/frontend/src/components/Card.vue
@@ -155,7 +155,7 @@ onMounted(() => {
 }
 
 .card-text-wrapper {
-  font-size: 17.4px;
+  font-size: 15px;
 }
 
 .card-header-wrapper {
@@ -204,7 +204,7 @@ onMounted(() => {
     margin-left: 2vw;
   }
   .card-text-wrapper {
-    font-size: 17.4px;
+    font-size: 15px;
     margin-left: 2vw;
   }
 }


### PR DESCRIPTION
With regards to Issue #152 , I have changed the font size from 12.4px to 15px so that the description in the API cards is more readable.

## Before 
![APIVault _ before](https://github.com/Exifly/ApiVault/assets/110970889/f9fb4121-704e-4d9d-ae1e-256806f51365)

## After
![APIVault _ after_](https://github.com/Exifly/ApiVault/assets/110970889/1d047d20-9fa3-45c7-99c2-b11efc7122fd)

