### PR TITLE
NEW-API: MaaS | Musk as a Service

### DIFF
--- a/backend/data/entries.json
+++ b/backend/data/entries.json
@@ -8407,6 +8407,15 @@
          "Category": "News"
       },
       {
+         "API": "MaaS | Musk as a Service",
+         "Description": " API to fetch random news articles which mention Elon Musk",
+         "Auth": "",
+         "HTTPS": true,
+         "Cors": "no",
+         "Link": "https://elonmu.sh/api",
+         "Category": "News"
+      },
+      {
          "API": "New York Times",
          "Description": "The New York Times Developer Network",
          "Auth": "apiKey",


### PR DESCRIPTION
#145 

API Information
API Name: MaaS | Musk as a Service
Description: API to fetch random news articles which mention Elon Musk
Category: News
What Auth is used (ex: Api Key): None
HTTPS: true
CORS: false
Api Link: https://elonmu.sh/api