### PR TITLE
fixed broken png url on image meta tag

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -59,12 +59,12 @@ export default defineNuxtConfig({
         { name: "twitter:card", content: "summary_large_image"},
         { name: "twitter:site", content: "apivault"},
         { name: "twitter:keywords", content: "free api, free api list, apivault, free apis for projects, open-source, public APIs, free apis for learning, free apis to use"},
-        { name: "twitter:image", content: "https://raw.githubusercontent.com/Exifly/ApiVault/main/assets/Hero.jpg"},
+        { name: "twitter:image", content: "https://raw.githubusercontent.com/Exifly/ApiVault/main/assets/Hero.png"},
         { property: "og:title", content: "A free API database list for developers"},
         { property: "og:description", content: "ApiVault - The largest collection of free public APIs, categorized for easy search."},
         { property: "og:site_name", content: "APIVault"},
         { property: "og:url", content: "https://apivault.dev/"},
-        { property: "og:image", content: "https://raw.githubusercontent.com/Exifly/ApiVault/main/assets/Hero.jpg" },
+        { property: "og:image", content: "https://raw.githubusercontent.com/Exifly/ApiVault/main/assets/Hero.png" },
         { property: "og:type", content: "website"}
       ]
     }


### PR DESCRIPTION
## Description
The old url used in meta tags was broken.
This pr replace old url with the new one using this image as website preview:
![image](https://github.com/Exifly/ApiVault/assets/19678157/0d118cf9-95fc-45d6-990f-239377efa51b)


## Checklist
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [ ] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [ ] My submission has a useful description
- [ ] Code follows the established [CODE_OF_CONDUCT](https://github.com/Exifly/ApiVault/blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Code has been tested thoroughly.
- [ ] All commit messages are descriptive and follow the established commit message format.
- [ ] Pull request description clearly describes the changes included in the pull request.
- [ ] I have searched the repository for any relevant issues or pull requests
- [ ] Any category I am creating has the minimum requirement of 3 items
