### PR TITLE
feat(dropdown): Persist filter dropdown value between pages

### DIFF
--- a/frontend/components/FilterDropdown.vue
+++ b/frontend/components/FilterDropdown.vue
@@ -1,22 +1,28 @@
 <template>
   <select
-    v-model="order"
+    v-model="filter"
     class="ps-1 px-3 text-wrapper inverted-input-box api-filter-select"
     aria-label="Filter"
     @change="orderApis"
   >
-    <option value="name" selected>Alphabetical</option>
+    <option value="name">Alphabetical</option>
     <option value="-likes_count">Likes</option>
   </select>
 </template>
 
 <script lang="ts" setup>
-const order = ref<string>("name");
+import { onMounted } from 'vue';
+import { useApiFilter } from "../composables/useApiFilter";
+const { filter } = useApiFilter();
 const emit = defineEmits(["filter:option"]);
 
 function orderApis() {
-  emit("filter:option", order.value);
+  emit("filter:option", filter.value);
 }
+
+onMounted(() => {
+  emit("filter:option", filter.value);
+});
 </script>
 
 <style scoped>

--- a/frontend/composables/useApiFilter.ts
+++ b/frontend/composables/useApiFilter.ts
@@ -1,0 +1,26 @@
+import type { Ref } from 'vue';
+import { watch } from 'vue';
+import { useState } from 'nuxt/app';
+
+export function useApiFilter(): { filter: Ref<string> } {
+  const filter = useState<string>('apiFilter', () => 'name');
+
+  if (process.client) {
+    const stored = localStorage.getItem('apiFilter');
+    if (stored && stored !== filter.value) {
+      filter.value = stored;
+    }
+
+    watch(
+      filter,
+      (newValue) => {
+        localStorage.setItem('apiFilter', newValue);
+      },
+      { immediate: false }
+    );
+  }
+
+  return { filter };
+}
+
+

--- a/frontend/pages/categories/[category].vue
+++ b/frontend/pages/categories/[category].vue
@@ -65,6 +65,7 @@
 </template>
 
 <script lang="ts" setup>
+import { watch } from 'vue';
 import { APIType } from "../../models/types";
 import ApivaultServices from "../../services/ApivaultServices";
 
@@ -117,9 +118,10 @@ const handleSearchCategory = (val: string, title: string) => {
 };
 
 /* Handle filter selection event */
-const filter = ref<string>();
+import { useApiFilter } from "../../composables/useApiFilter";
+const { filter } = useApiFilter();
 function handleFilterSelection(filterValue: string) {
-  filter.value = filterValue; 
+  filter.value = filterValue;
   fillApiCards(filter.value);
 }
 
@@ -144,9 +146,14 @@ async function fillApiCards(filter: string) {
   if (filter) { apiSearched.value = apiData.value };
 }
 
-onMounted(async () => {
-  await fillApiCards(filter.value!);
-});
+/* Re-fetch when category changes, keep same filter */
+watch(
+  () => route.params.category,
+  async () => {
+    await fillApiCards(filter.value!);
+  },
+  { immediate: true }
+);
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Description

Adds a composable `useApiFilter()` to persist the user’s selected filter across page navigations and reloads. Wires it into `FilterDropdown.vue` and the categories page so the persisted value is used on initial load and when switching categories.

## Proposed Changes

- New `frontend/composables/useApiFilter.ts`: stores the current filter in `useState('apiFilter')` and syncs to localStorage on the client.
- Update `frontend/components/FilterDropdown.vue`:
  - Bind v-model to the shared filter from the composable.
  - Emit the current value on mount so parent views initialize correctly.
- Update `frontend/pages/categories/[category].vue`:
  - Use the shared filter and refetch when route.params.category changes (watch(..., { immediate: true })).
  - Remove redundant local filter state and the extra onMounted fetch.

## Checklist
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->
- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My submission has a useful description
- [x] Code follows the established [CODE_OF_CONDUCT](https://github.com/Exifly/ApiVault/blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Code has been tested thoroughly.
- [x] All commit messages are descriptive and follow the established commit message format.
- [x] Pull request description clearly describes the changes included in the pull request.
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
